### PR TITLE
Fix fetchStatus repeat flag handling

### DIFF
--- a/public/static/js/botHandler.js
+++ b/public/static/js/botHandler.js
@@ -35,7 +35,7 @@ export function initBotControl() {
         toast: false,
       });
 
-      await fetchStatus();
+      await fetchStatus(true);
     } catch (e) {
       Swal.fire({
         icon: "error",

--- a/public/static/js/statusHandler.js
+++ b/public/static/js/statusHandler.js
@@ -10,7 +10,7 @@ export function updateStatus(data) {
   stopBtn.disabled = !data.active;
 }
 
-export async function fetchStatus() {
+export async function fetchStatus(repeat = false) {
   try {
     const res = await fetch("/bot/status");
     const data = await res.json();


### PR DESCRIPTION
## Summary
- add an optional repeat flag to fetchStatus so the retry logic no longer references an undefined variable
- trigger repeated status polling only after starting the bot by invoking fetchStatus with the repeat flag

## Testing
- node --input-type=module <<'NODE'
import vm from 'node:vm';
import { readFile } from 'node:fs/promises';

const elements = {
  status: { textContent: '', disabled: false },
  startBtn: { disabled: false },
  stopBtn: { disabled: true },
};

const context = {
  console,
  setTimeout,
  clearTimeout,
  fetch: async () => ({ json: async () => ({ active: true }) }),
  document: { getElementById: (id) => elements[id] || null },
};

const moduleContext = vm.createContext(context);
const code = await readFile('./public/static/js/statusHandler.js', 'utf8');
const module = new vm.SourceTextModule(code, { context: moduleContext });
await module.link(() => {
  throw new Error('Unexpected import in statusHandler.js');
});
await module.evaluate();
const { fetchStatus } = module.namespace;
await fetchStatus();
console.log(elements);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cbcbeb6a7083269824636dcab0c6e4