### PR TITLE
Handle missing logs when generating stats

### DIFF
--- a/public/static/js/chartHandler.js
+++ b/public/static/js/chartHandler.js
@@ -5,10 +5,23 @@ export async function renderCharts() {
     const res = await fetch("/stats");
     const data = await res.json();
 
-    const labels = Object.keys(data.messagesPerDay).sort();
-    const messages = labels.map((d) => data.messagesPerDay[d] || 0);
-    const errors = labels.map((d) => data.errorsPerDay[d] || 0);
-    const uptime = labels.map((d) => data.uptimePerDay[d] || 0);
+    const {
+      messagesPerDay = {},
+      errorsPerDay = {},
+      uptimePerDay = {},
+    } = data || {};
+
+    const labels = Array.from(
+      new Set([
+        ...Object.keys(messagesPerDay),
+        ...Object.keys(errorsPerDay),
+        ...Object.keys(uptimePerDay),
+      ])
+    ).sort();
+
+    const messages = labels.map((d) => messagesPerDay[d] || 0);
+    const errors = labels.map((d) => errorsPerDay[d] || 0);
+    const uptime = labels.map((d) => uptimePerDay[d] || 0);
 
     const isDark = document.body.classList.contains("dark");
     const gridColor = isDark ? "#4b5563" : "#e5e7eb";


### PR DESCRIPTION
## Summary
- ensure the stats route creates the logs directory before reading and catches aggregation failures
- keep returning an empty stats object when parsing fails instead of throwing
- make the dashboard chart tolerate empty or partial stats responses without errors

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbcbec3b848326b0c6b42bf7f02827