### PR TITLE
Align container ports and volume mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN mkdir -p logs
 
 # Expose port
-EXPOSE 3001
+EXPOSE 3000
 
 # Command to run app
 CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     build: .
     container_name: sigap
     ports:
-      - "3003:3000"
+      - "3000:3000"
     volumes:
-      - ./sessions:/app/sessions
-      - ./logs:/app/logs
-      - ./config:/app/config:ro
-      - ./.wwebjs_auth:/app/.wwebjs_auth
-      - ./.wwebjs_cache:/app/.wwebjs_cache
+      - ./sessions:/usr/src/app/sessions
+      - ./logs:/usr/src/app/logs
+      - ./config:/usr/src/app/config:ro
+      - ./.wwebjs_auth:/usr/src/app/.wwebjs_auth
+      - ./.wwebjs_cache:/usr/src/app/.wwebjs_cache
     env_file:
       - .env.production
 


### PR DESCRIPTION
## Summary
- align docker compose volume mounts with /usr/src/app so session, log, and config data persist
- expose the default Express port 3000 and map it through docker compose

## Testing
- docker compose up --build *(fails in the execution environment because Docker is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbed9e7c83269f9c2acca7fe8893