### PR TITLE
Add API key middleware for control routes

### DIFF
--- a/.env
+++ b/.env
@@ -26,3 +26,6 @@ DEFAULT_LANGUAGE=id
 
 # ===== Database =====
 JOB_TIME=15:30
+
+# ===== API Access Control =====
+CONTROL_API_KEY=change_me

--- a/.env.production
+++ b/.env.production
@@ -22,3 +22,6 @@ DEFAULT_LANGUAGE=id
 
 # ===== Production Environment =====
 NODE_ENV=production
+
+# ===== API Access Control =====
+CONTROL_API_KEY=ubah_ini

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ WhatsApp Reminder Bot (SIGAP) adalah aplikasi bot WhatsApp yang berfungsi untuk 
    TIMEZONE=TIMEZONE_KAMU
    GOOGLE_CREDENTIALS_PATH=PATH_CREDNTIALS_KAMU
    SPREADSHEET_ID=ID_GOOGLE_SHEET_KAMU
+   CONTROL_API_KEY=API_KEY_KONTROL_KAMU
 
    ```
+
+   Gunakan nilai `CONTROL_API_KEY` untuk mengamankan endpoint kontrol bot dan editor template. Kunci ini wajib dikirimkan oleh klien ketika mengakses API terkait.
 
 ## Menjalankan Aplikasi
 
@@ -76,6 +79,14 @@ node index.js
 - Buka browser dan akses `http://localhost:port` untuk membuka dashboard.
 - Dashboard menampilkan log realtime, tombol start/stop bot, status koneksi, dan chart statistik.
 - Gunakan fitur filter log dan toggle dark mode di dashboard.
+
+## Autentikasi API Kontrol
+
+- Semua request ke endpoint `/bot` dan `/template` kini memerlukan API key.
+- Sertakan header `x-api-key: <CONTROL_API_KEY>` pada setiap request. Alternatifnya, gunakan header `Authorization: Bearer <CONTROL_API_KEY>`.
+- Jika header tidak dikirim, server akan mengembalikan status **401 Unauthorized**.
+- Jika kunci salah, server akan mengembalikan status **403 Forbidden**.
+- Pastikan variabel environment `CONTROL_API_KEY` terkonfigurasi di server atau file `.env` sebelum menjalankan aplikasi.
 
 ## Struktur Folder
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const { stopHeartbeat } = require("./utils/heartbeat");
 const { addLog } = require("./controllers/logController");
 const { initSocket } = require("./utils/socketHandler");
 const { runDailyJob } = require("./jobs/dailyJob");
+const apiKeyAuth = require("./middleware/apiKeyAuth");
 
 // Inisialisasi dotenv untuk mengakses variabel lingkungan
 require("dotenv").config();
@@ -58,10 +59,10 @@ const messageRoutes = require("./routes/messageRoutes");
 const systemRoutes = require("./routes/systemRoutes");
 const templateRoutes = require("./routes/templateRoutes");
 
-app.use("/bot", botRoutes);
+app.use("/bot", apiKeyAuth, botRoutes);
 app.use("/send", messageRoutes);
 app.use("/", systemRoutes);
-app.use("/template", templateRoutes);
+app.use("/template", apiKeyAuth, templateRoutes);
 
 // Start server via HTTP server (bukan app.listen)
 server.listen(PORT, () => {

--- a/middleware/apiKeyAuth.js
+++ b/middleware/apiKeyAuth.js
@@ -1,0 +1,54 @@
+const HEADER_NAME = "x-api-key";
+
+function extractKey(req) {
+  const headerKey = req.get(HEADER_NAME);
+  if (headerKey) {
+    return headerKey.trim();
+  }
+
+  const authHeader = req.get("authorization");
+  if (!authHeader) {
+    return null;
+  }
+
+  const trimmedAuth = authHeader.trim();
+  if (!trimmedAuth) {
+    return null;
+  }
+
+  const [scheme, token] = trimmedAuth.split(/\s+/, 2);
+  if (scheme && scheme.toLowerCase() === "bearer" && token) {
+    return token.trim();
+  }
+
+  return trimmedAuth;
+}
+
+module.exports = function apiKeyAuth(req, res, next) {
+  const configuredKey = process.env.CONTROL_API_KEY || process.env.API_KEY;
+  const expectedKey =
+    typeof configuredKey === "string" ? configuredKey.trim() : "";
+
+  if (!expectedKey) {
+    console.error(
+      "[Auth] API key middleware aktif tetapi variabel lingkungan CONTROL_API_KEY/API_KEY belum diset."
+    );
+    return res
+      .status(500)
+      .json({ message: "API key server belum dikonfigurasi." });
+  }
+
+  const providedKey = extractKey(req);
+
+  if (!providedKey) {
+    return res
+      .status(401)
+      .json({ message: "API key diperlukan untuk mengakses endpoint ini." });
+  }
+
+  if (providedKey !== expectedKey) {
+    return res.status(403).json({ message: "API key tidak valid." });
+  }
+
+  return next();
+};


### PR DESCRIPTION
## Summary
- add an API key middleware that enforces CONTROL_API_KEY/ API_KEY headers for sensitive routes
- protect the /bot and /template routers with the middleware so every control request is authenticated
- document the new CONTROL_API_KEY requirement in the environment examples and README

## Testing
- curl -i http://localhost:4100/bot/status
- curl -i -H 'x-api-key: wrong' http://localhost:4100/bot/status
- curl -i -H 'x-api-key: test-key' http://localhost:4100/bot/status

------
https://chatgpt.com/codex/tasks/task_e_68cbcbf660a08326bc73fce5c38c537c