### PR TITLE
Fix status polling repeat parameter

### DIFF
--- a/public/static/js/statusHandler.js
+++ b/public/static/js/statusHandler.js
@@ -16,7 +16,7 @@ export async function fetchStatus(repeat = false) {
     const data = await res.json();
     updateStatus(data);
 
-    if (shouldRepeat && !data.active) {
+    if (repeat && !data.active) {
       setTimeout(() => fetchStatus(true), 1000); // coba lagi tiap 1 detik
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- update the dashboard status polling logic to use the existing `repeat` flag instead of an undefined variable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cca1d3b20c8326a9a12952827c0fef