### PR TITLE
Add template editor hooks and UI to admin dashboard

### DIFF
--- a/frontend/src/queries/templates.js
+++ b/frontend/src/queries/templates.js
@@ -1,0 +1,67 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiRequest } from '../lib/apiClient';
+
+const TEMPLATE_QUERY_KEY = ['templates', 'message'];
+const API_KEY = import.meta.env.VITE_CONTROL_API_KEY || '';
+
+function withApiKey(options = {}) {
+  const headers = {
+    ...(options.headers || {}),
+  };
+
+  if (API_KEY) {
+    headers['x-api-key'] = API_KEY;
+  }
+
+  return {
+    ...options,
+    headers,
+  };
+}
+
+function normalizeTemplateResponse(payload) {
+  if (!payload) {
+    return '';
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (typeof payload === 'object' && typeof payload.template === 'string') {
+    return payload.template;
+  }
+
+  return '';
+}
+
+export function useTemplate() {
+  return useQuery({
+    queryKey: TEMPLATE_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiRequest('/api/templates', withApiKey());
+      return normalizeTemplateResponse(response);
+    },
+  });
+}
+
+export function useSaveTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (template) =>
+      apiRequest(
+        '/api/templates',
+        withApiKey({
+          method: 'POST',
+          body: { template },
+        })
+      ),
+    onSuccess: (_, template) => {
+      queryClient.setQueryData(TEMPLATE_QUERY_KEY, template);
+      queryClient.invalidateQueries({ queryKey: TEMPLATE_QUERY_KEY });
+    },
+  });
+}
+
+export { TEMPLATE_QUERY_KEY };


### PR DESCRIPTION
## Summary
- add React Query hooks for loading and saving message templates with API key headers
- extend the admin dashboard with a message template editor card complete with loading, error, and dirty states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd0a78015c83268be2d1a01b1ef7a5