### PR TITLE
Add React Query Devtools dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.89.0",
+    "@tanstack/react-query-devtools": "^5.89.0",
     "clsx": "^2.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2088,6 +2088,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.89.0",
+        "@tanstack/react-query-devtools": "^5.89.0",
         "clsx": "^2.1.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add @tanstack/react-query-devtools to the frontend workspace dependencies to match the existing React Query usage
- update the workspace lockfile entry to include the new dependency reference

## Testing
- npm install --workspace frontend *(fails: 403 Forbidden fetching @tanstack/react-query-devtools from the npm registry in this environment)*
- npm --workspace frontend run build *(fails: module resolution error because the new dependency could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd16ca5af48326a4721ac275c09b60