### PR TITLE
Fix placeholder usage in admin templates page

### DIFF
--- a/frontend/src/pages/AdminTemplatesPage.jsx
+++ b/frontend/src/pages/AdminTemplatesPage.jsx
@@ -15,10 +15,16 @@ export default function AdminTemplatesPage() {
   const { data, isLoading } = useTemplate();
   const updateMutation = useUpdateTemplate();
 
+  const NAME_PLACEHOLDER = '{name}';
+  const QUOTE_PLACEHOLDER = '{quote}';
+
   const [template, setTemplate] = useState('');
   const [filterName, setFilterName] = useState('');
   const preview = useMemo(
-    () => template.replaceAll('{name}', filterName || 'Nama').replaceAll('{quote}', 'Kutipan hari ini'),
+    () =>
+      template
+        .replaceAll(NAME_PLACEHOLDER, filterName || 'Nama')
+        .replaceAll(QUOTE_PLACEHOLDER, 'Kutipan hari ini'),
     [template, filterName]
   );
 
@@ -44,7 +50,8 @@ export default function AdminTemplatesPage() {
           <div className="space-y-2">
             <h1 className="text-2xl font-semibold text-white">Pengaturan Template Pesan</h1>
             <p className="text-sm text-slate-400">
-              Gunakan placeholder <code>{'{name}'}</code> dan <code>{'{quote}'}</code> untuk menyisipkan nama dan kutipan.
+              Gunakan placeholder <code>{NAME_PLACEHOLDER}</code> dan <code>{QUOTE_PLACEHOLDER}</code> untuk menyisipkan nama
+              dan kutipan.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- declare reusable constants for the name and quote placeholders in the admin templates page
- update the preview memoization and helper text to use the new constants and avoid undefined identifiers

## Testing
- npm --workspace frontend run lint *(fails: existing parsing and lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce148f7b8c8326844cd0d77a8e1b57