### PR TITLE
Fix start button markup

### DIFF
--- a/frontend/src/components/BotControlPanel.jsx
+++ b/frontend/src/components/BotControlPanel.jsx
@@ -32,7 +32,12 @@ export function BotControlPanel() {
         </div>
 
         <div className="flex flex-wrap gap-3">
-          <Button variant="success" <Button disabled={starting || active} type="button" onClick={() => startMutation.mutate()}>
+          <Button
+            variant="success"
+            disabled={starting || active}
+            type="button"
+            onClick={() => startMutation.mutate()}
+          >
             {starting && <Spinner size="sm" className="mr-2" />}
             {starting ? "Mengaktifkan..." : "Start Bot"}
           </Button>


### PR DESCRIPTION
## Summary
- correct the Start Bot button markup to use a single success-variant button while preserving existing behavior

## Testing
- npm --workspace frontend run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce14954f88832694f376915c593e66