### PR TITLE
Configure Chromium for backend Puppeteer runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,34 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:20-alpine AS base
-WORKDIR /app
+FROM node:20-slim AS base
+
 ENV NODE_ENV=production
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    chromium \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    libxshmfence1 \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 FROM base AS deps
 COPY package.json package-lock.json ./

--- a/backend/src/controllers/botController.js
+++ b/backend/src/controllers/botController.js
@@ -20,14 +20,20 @@ async function startBot() {
     return;
   }
 
+  const puppeteerOptions = {
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  };
+
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    puppeteerOptions.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+
   client = new Client({
     authStrategy: new LocalAuth({
       dataPath: path.join(__dirname, "..", "..", "storage", "sessions"),
     }),
-    puppeteer: {
-      headless: true,
-      args: ["--no-sandbox", "--disable-setuid-sandbox"],
-    },
+    puppeteer: puppeteerOptions,
   });
 
   client.on("qr", (qr) => {


### PR DESCRIPTION
## Summary
- switch the backend Docker image to Debian-based node:20-slim and install Chromium with required libraries via apt-get
- export the Chromium binary path through PUPPETEER_EXECUTABLE_PATH for runtime use
- update the WhatsApp bot controller to honour the PUPPETEER_EXECUTABLE_PATH environment variable when configuring Puppeteer

## Testing
- docker compose build backend *(fails: `docker` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce191a626c83269e07ce6622a87b76