### PR TITLE
Align timezone usage in logging and keepalive endpoint

### DIFF
--- a/backend/src/controllers/logController.js
+++ b/backend/src/controllers/logController.js
@@ -1,4 +1,5 @@
 const moment = require("moment-timezone");
+const config = require("../config/env");
 const { setupLogger } = require("../utils/logger");
 const { emitLogUpdate } = require("../utils/socketHandler");
 
@@ -8,7 +9,7 @@ const MAX_LOG_ENTRIES = 100;
 const logs = [];
 
 function addLog(text, level = "info") {
-  const time = moment().format("HH:mm:ss");
+  const time = moment().tz(config.timezone).format("HH:mm:ss");
   const logEntry = `[${time}] ${text}`;
 
   if (logs.length >= MAX_LOG_ENTRIES) {
@@ -45,7 +46,7 @@ function getStats() {
   };
 
   for (const log of logs) {
-    const todayStr = moment().format("YYYY-MM-DD");
+    const todayStr = moment().tz(config.timezone).format("YYYY-MM-DD");
 
     if (log.includes("Pesan") || log.includes("Mengirim ke")) {
       stats.messagesPerDay[todayStr] =

--- a/backend/src/routes/systemRoutes.js
+++ b/backend/src/routes/systemRoutes.js
@@ -33,7 +33,7 @@ router.get('/qr', (req, res) => {
 });
 
 router.get('/keepalive', (req, res) => {
-  const now = moment().toISOString();
+  const now = moment().tz(TIMEZONE).toISOString();
   addLog(`[KeepAlive] Ping diterima pada ${now}`);
   res.json({ status: 'alive', timestamp: now });
 });


### PR DESCRIPTION
## Summary
- load the shared environment config inside the log controller
- apply the configured timezone to log timestamp formatting
- ensure the keepalive route timestamps use the configured timezone

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce191e9ac483268932f502ec9ea03c