### PR TITLE
Handle missing calendar token without prompt

### DIFF
--- a/backend/src/services/calendarHoliday.js
+++ b/backend/src/services/calendarHoliday.js
@@ -7,7 +7,13 @@ const { authorize } = require("./calendarAuth");
  * @returns {Promise<Array>}
  */
 async function getTodayIsHoliday(date = new Date()) {
-  const auth = await authorize();
+  let auth;
+  try {
+    auth = await authorize();
+  } catch (err) {
+    err.message = `Gagal otorisasi Google Calendar: ${err.message}`;
+    throw err;
+  }
   const calendar = google.calendar({ version: "v3", auth });
 
   // Buat rentang waktu dari jam 00:00 sampai 23:59 tanggal tsb


### PR DESCRIPTION
## Summary
- prevent automated uses of `authorize` from prompting for interactive login when the calendar token is missing or invalid
- surface authorization failures through `getTodayIsHoliday` so holiday lookups can fall back to local data

## Testing
- `npm run lint --workspace backend`


------
https://chatgpt.com/codex/tasks/task_e_68ce210d13d0832698dc502c476df1ce